### PR TITLE
Add subcommand to remove Git filter configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/
 /dist/
 /nb_clean.egg-info/
+__pycache__/

--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-Copyright © 2017 Scott Stevenson <scott@stevenson.io>
+Copyright © 2017-2018 Scott Stevenson <scott@stevenson.io>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Jupyter notebook manually with:
 Copyright
 ---------
 
-Copyright © 2017 `Scott Stevenson`_.
+Copyright © 2017-2018 `Scott Stevenson`_.
 
 ``nb-clean`` is distributed under the terms of the `ISC licence`_.
 

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,12 @@ notebooks before they are staged, run the following from the working tree:
     nb-clean configure-git
 
 ``nb-clean`` will configure a filter in the Git repository in which it is run,
-and will not mutate your global or system Git configuration.
+and will not mutate your global or system Git configuration. To remove the
+filter, run:
+
+.. code-block:: bash
+
+    nb-clean unconfigure-git
 
 Aside from usage from a filter in a Git repository, you can also clean up a
 Jupyter notebook manually with:

--- a/nb-clean
+++ b/nb-clean
@@ -81,6 +81,27 @@ def configure_git(_: argparse.Namespace) -> None:
         file.write(f'\n{ATTRIBUTE}\n')
 
 
+def unconfigure_git(_: argparse.Namespace) -> None:
+    """Remove nb-clean filter from the Git repository.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Arguments parsed from the command line.
+
+    """
+    git_dir = git(['rev-parse', '--git-dir'])
+    attrs = Path(git_dir) / 'info' / 'attributes'
+
+    if attrs.is_file():
+        original_contents = attrs.read_text().split('\n')
+        revised_contents = [line for line in original_contents
+                            if line != ATTRIBUTE]
+        attrs.write_text('\n'.join(revised_contents))
+
+    git(['config', '--remove-section', 'filter.nb-clean'])
+
+
 def clean(args: argparse.Namespace) -> None:
     """Clean notebook of execution counts and output.
 
@@ -110,6 +131,11 @@ def main() -> None:
         'configure-git',
         help='configure Git filter to clean notebooks before staging')
     configure_parser.set_defaults(func=configure_git)
+
+    unconfigure_parser = subparsers.add_parser(
+        'unconfigure-git',
+        help='remove Git filter that cleans notebooks before staging')
+    unconfigure_parser.set_defaults(func=unconfigure_git)
 
     clean_parser = subparsers.add_parser(
         'clean',

--- a/nb-clean
+++ b/nb-clean
@@ -60,7 +60,7 @@ def git(args: List[str]) -> str:
     return process.stdout.decode().strip()
 
 
-def attributes_path():
+def attributes_path() -> Path:
     """Get the attributes file path for the current Git repository.
 
     Returns

--- a/nb-clean
+++ b/nb-clean
@@ -89,12 +89,12 @@ def configure_git(_: argparse.Namespace) -> None:
     """
     git(['config', 'filter.nb-clean.clean', 'nb-clean clean'])
 
-    attrs = attributes_path()
+    attributes = attributes_path()
 
-    if attrs.is_file() and ATTRIBUTE in attrs.read_text():
+    if attributes.is_file() and ATTRIBUTE in attributes.read_text():
         return
 
-    with attrs.open('a') as file:
+    with attributes.open('a') as file:
         file.write(f'\n{ATTRIBUTE}\n')
 
 
@@ -107,13 +107,13 @@ def unconfigure_git(_: argparse.Namespace) -> None:
         Arguments parsed from the command line.
 
     """
-    attrs = attributes_path()
+    attributes = attributes_path()
 
-    if attrs.is_file():
-        original_contents = attrs.read_text().split('\n')
+    if attributes.is_file():
+        original_contents = attributes.read_text().split('\n')
         revised_contents = [line for line in original_contents
                             if line != ATTRIBUTE]
-        attrs.write_text('\n'.join(revised_contents))
+        attributes.write_text('\n'.join(revised_contents))
 
     git(['config', '--remove-section', 'filter.nb-clean'])
 

--- a/nb-clean
+++ b/nb-clean
@@ -11,6 +11,7 @@ from typing import List
 import nbformat
 
 PROGRAM = Path(sys.argv[0]).name
+ATTRIBUTE = '*.ipynb filter=nb-clean'
 
 
 def error(message: str, code: int) -> None:
@@ -73,11 +74,11 @@ def configure_git(_: argparse.Namespace) -> None:
     git_dir = git(['rev-parse', '--git-dir'])
     attrs = Path(git_dir) / 'info' / 'attributes'
 
-    if attrs.is_file() and 'filter=nb-clean' in attrs.read_text():
+    if attrs.is_file() and ATTRIBUTE in attrs.read_text():
         return
 
     with attrs.open('a') as file:
-        file.write('\n*.ipynb filter=nb-clean\n')
+        file.write(f'\n{ATTRIBUTE}\n')
 
 
 def clean(args: argparse.Namespace) -> None:

--- a/nb-clean
+++ b/nb-clean
@@ -60,6 +60,24 @@ def git(args: List[str]) -> str:
     return process.stdout.decode().strip()
 
 
+def attributes_path():
+    """Get the attributes file path for the current Git repository.
+
+    Returns
+    -------
+    Path
+        Path to the Git attributes file.
+
+    Examples
+    --------
+    >>> attributes_path()
+    PosixPath('.git/info/attributes')
+
+    """
+    git_dir = git(['rev-parse', '--git-dir'])
+    return Path(git_dir) / 'info' / 'attributes'
+
+
 def configure_git(_: argparse.Namespace) -> None:
     """Configure Git repository to use nb-clean filter.
 
@@ -71,8 +89,7 @@ def configure_git(_: argparse.Namespace) -> None:
     """
     git(['config', 'filter.nb-clean.clean', 'nb-clean clean'])
 
-    git_dir = git(['rev-parse', '--git-dir'])
-    attrs = Path(git_dir) / 'info' / 'attributes'
+    attrs = attributes_path()
 
     if attrs.is_file() and ATTRIBUTE in attrs.read_text():
         return
@@ -90,8 +107,7 @@ def unconfigure_git(_: argparse.Namespace) -> None:
         Arguments parsed from the command line.
 
     """
-    git_dir = git(['rev-parse', '--git-dir'])
-    attrs = Path(git_dir) / 'info' / 'attributes'
+    attrs = attributes_path()
 
     if attrs.is_file():
         original_contents = attrs.read_text().split('\n')


### PR DESCRIPTION
With this change, the Git filter configuration added by `nb-clean configure-git` can be removed again with `nb-clean unconfigure-git`.

Closes #3.