### PR TITLE
Remove metadata from all cells

### DIFF
--- a/nb-clean
+++ b/nb-clean
@@ -131,6 +131,7 @@ def clean(args: argparse.Namespace) -> None:
     notebook = nbformat.read(args.input, as_version=nbformat.NO_CONVERT)
 
     for cell in notebook.cells:
+        cell['metadata'] = {}
         if cell['cell_type'] == 'code':
             cell['execution_count'] = None
             cell['outputs'] = []


### PR DESCRIPTION
This PR adds cleaning of the metadata from each cell in the notebook: previously only the execution count and output were cleaned, with the metadata left in place.

Closes #8.