### PR TITLE
Add mypy configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ install:
   - pip install pipenv
   - pipenv install --dev --skip-lock
 script:
+  - pipenv run mypy
   - make check

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 NAME = nb-clean
 
 check:
-	pipenv run mypy
 	pipenv run flake8
 	pipenv run pylint
 

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,8 @@ twine = "*"
 python_version = "3.6"
 
 [scripts]
+# We pass `--strict` here as mypy does not support specifying it in the
+# `mypy.ini` configuration file.
+mypy = "mypy --strict nb-clean setup.py"
 flake8 = "flake8 nb-clean setup.py"
-mypy = "mypy --ignore-missing-imports --strict nb-clean setup.py"
 pylint = "pylint -d invalid-name -r n -s n nb-clean setup.py"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True


### PR DESCRIPTION
Configuring mypy with a configuration file rather than by passing command line arguments in `Pipfile` enables editors to automatically run mypy with the correct configuration. Additionally, mypy is now run via Pipenv directly in CI rather than via Make.