### PR TITLE
Set check argument of subprocess.run explicitly

### DIFF
--- a/src/nb_clean.py
+++ b/src/nb_clean.py
@@ -46,7 +46,10 @@ def git(*args: str) -> str:
 
     """
     process = subprocess.run(
-        ["git"] + list(args), stderr=subprocess.PIPE, stdout=subprocess.PIPE
+        ["git"] + list(args),
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        check=False,
     )
 
     if process.returncode == 128:


### PR DESCRIPTION
This is now recommended by Pylint.