### PR TITLE
Remove return code check

### DIFF
--- a/src/nb_clean.py
+++ b/src/nb_clean.py
@@ -53,9 +53,6 @@ def git(*args: str) -> str:
         check=False,
     )
 
-    if process.returncode == 128:
-        error("not in a Git repository", 64)
-
     if process.returncode:
         error(process.stderr.decode(), process.returncode)
 


### PR DESCRIPTION
A 128 return code from `git rev-parse --git-dir` indicates that the current directory isn't a Git repository. However, when running `git config --remove-section` a 128 return code instead indicates that the specified section does not exist.

Therefore rather than treating 128 as a special case and printing our own error message, just pass through the error message from the Git CLI.

Thanks to @shwinnn for reporting this.