### PR TITLE
Remove python version from language info metadata.

### DIFF
--- a/src/nb_clean/__init__.py
+++ b/src/nb_clean/__init__.py
@@ -217,4 +217,9 @@ def clean_notebook(
             cell["execution_count"] = None
             cell["outputs"] = []
 
+    try:
+        del notebook["metadata"]["language_info"]["version"]
+    except KeyError:
+        pass
+
     return notebook

--- a/src/nb_clean/__init__.py
+++ b/src/nb_clean/__init__.py
@@ -182,6 +182,13 @@ def check_notebook(
                 print(f"{prefix}: outputs")
                 is_clean = False
 
+    try:
+        language_version = notebook["metadata"]["language_info"]["version"]
+        print(f"Language version found: {language_version}")
+        is_clean = False
+    except KeyError:
+        pass
+
     return is_clean
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,11 @@ def dirty_notebook() -> nbformat.NotebookNode:
     """A dirty notebook."""
     return read_notebook("dirty.ipynb")
 
+@pytest.fixture
+def dirty_notebook_with_version() -> nbformat.NotebookNode:
+    """A dirty notebook with the python version."""
+    return read_notebook("dirty_with_version.ipynb")
+
 
 @pytest.fixture
 def clean_notebook() -> nbformat.NotebookNode:

--- a/tests/notebooks/clean.ipynb
+++ b/tests/notebooks/clean.ipynb
@@ -25,8 +25,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/tests/notebooks/clean_with_empty_cells.ipynb
+++ b/tests/notebooks/clean_with_empty_cells.ipynb
@@ -39,8 +39,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/tests/notebooks/clean_with_metadata.ipynb
+++ b/tests/notebooks/clean_with_metadata.ipynb
@@ -27,8 +27,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/tests/notebooks/dirty_with_version.ipynb
+++ b/tests/notebooks/dirty_with_version.ipynb
@@ -1,0 +1,34 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Hello, world\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:Python3] *",
+   "language": "python",
+   "name": "conda-env-Python3-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_check_notebook.py
+++ b/tests/test_check_notebook.py
@@ -12,6 +12,7 @@ import nb_clean
         # pylint: disable=no-member
         (pytest.lazy_fixture("clean_notebook"), True),  # type: ignore
         (pytest.lazy_fixture("dirty_notebook"), False),  # type: ignore
+        (pytest.lazy_fixture("dirty_notebook_with_version"), False),  # type: ignore
     ],
 )
 def test_check_notebook(

--- a/tests/test_clean_notebook.py
+++ b/tests/test_clean_notebook.py
@@ -12,6 +12,13 @@ def test_clean_notebook(
     """Test nb_clean.clean_notebook."""
     assert nb_clean.clean_notebook(dirty_notebook) == clean_notebook
 
+def test_clean_notebook_with_version(
+    dirty_notebook_with_version: nbformat.NotebookNode,
+    clean_notebook: nbformat.NotebookNode,
+) -> None:
+    """Test nb_clean.clean_notebook."""
+    assert nb_clean.clean_notebook(dirty_notebook_with_version) == clean_notebook
+
 
 def test_clean_notebook_remove_empty_cells(
     clean_notebook_with_empty_cells: nbformat.NotebookNode,


### PR DESCRIPTION
Fix #49.

* Modify `clean_notebook` to remove python version from language info metadata.
* Make `check_notebook` return `False` if the notebook contains python version in language info metadata.
* Add test cases

```
$ poetry run pytest
================================== test session starts ===================================
[...]
tests/test_check_notebook.py .......                                               [ 20%]
tests/test_clean_notebook.py ....                                                  [ 31%]
tests/test_cli.py ..............                                                   [ 71%]
tests/test_git_integration.py ..........                                           [100%]

=================================== 35 passed in 0.23s ===================================
```