### PR TITLE
[WIP] Fix #77

### DIFF
--- a/src/nb_clean/__init__.py
+++ b/src/nb_clean/__init__.py
@@ -78,7 +78,9 @@ def git_attributes_path() -> pathlib.Path:
 
 
 def add_git_filter(
-    remove_empty_cells: bool = False, preserve_cell_metadata: bool = False
+    remove_empty_cells: bool = False,
+    preserve_cell_metadata: bool = False,
+    required: bool = False,
 ) -> None:
     """Add a filter to clean notebooks to the current Git repository.
 
@@ -88,6 +90,8 @@ def add_git_filter(
         If True, remove empty cells.
     preserve_cell_metadata : bool, default False
         If True, preserve cell metadata.
+    required : bool, default False
+        If True, require nb-clean before staging.
 
     Returns
     -------
@@ -103,6 +107,7 @@ def add_git_filter(
         command.append("--preserve-cell-metadata")
 
     git("config", "filter.nb-clean.clean", " ".join(command))
+    git("config", "filter.nb-clean.required", str(required))
 
     attributes_path = git_attributes_path()
 

--- a/src/nb_clean/__init__.py
+++ b/src/nb_clean/__init__.py
@@ -108,6 +108,7 @@ def add_git_filter(
 
     git("config", "filter.nb-clean.clean", " ".join(command))
     git("config", "filter.nb-clean.required", str(required))
+    git("config", "filter.nb-clean.smudge", "cat")
 
     attributes_path = git_attributes_path()
 

--- a/src/nb_clean/cli.py
+++ b/src/nb_clean/cli.py
@@ -45,6 +45,7 @@ def add_filter(args: argparse.Namespace) -> None:
         nb_clean.add_git_filter(
             remove_empty_cells=args.remove_empty_cells,
             preserve_cell_metadata=args.preserve_cell_metadata,
+            required=args.required,
         )
     except nb_clean.GitProcessError as exc:
         exit_with_error(exc.message, exc.return_code)
@@ -170,6 +171,12 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         "--preserve-cell-metadata",
         action="store_true",
         help="preserve cell metadata",
+    )
+    add_filter_parser.add_argument(
+        "-r",
+        "--required",
+        action="store_true",
+        help="require nb-clean pass before staging."
     )
     add_filter_parser.set_defaults(func=add_filter)
 


### PR DESCRIPTION
Add `--required` option to the filter subcommand.
Also add `smudge = cat` to ensure that _dirty_ notebooks aren't deleted with `required`.

- Now if `required = True` and the command fails, reverting (checking out) a modified file will _delete_ it!
	- Test by modifying a notebook from the repository
	- `git checkout -q -- <path-to-nb>`
	- Will return:	`fatal: <nb>: smudge filter nb-clean failed` and delete the notebook
- The common workaround is to include a smudge simply with `cat`, which I've done
	- I am not 100% sure what the possible side effects are

I have **not** written any tests, because I would like to discuss them with you first.
I don't really understand what the benefit of `mock_git.assert_called_once_with` is.
For my proposed code I would have to change the mock assertion.
This lets me believe that I am possibly adding _too much_ into the git_add function.
If the mock should implicitly ensure that the function is _only doing one thing_, then maybe it could be better to split this one function into multiple smaller ones?
What is your opinion on this?
I must say that I haven't really used `mock` before, so I am happy to learn the motivation behind counting the number of calls :)