### PR TITLE
Add support for preserving cell outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ use:
 nb-clean add-filter --preserve-cell-metadata
 ```
 
+To preserve cell outputs, use:
+
+```bash
+nb-clean add-filter --preserve-cell-outputs
+```
+
 `nb-clean` will configure a filter in the Git repository in which it is run, and
 won't mutate your global or system Git configuration. To remove the filter, run:
 
@@ -80,7 +86,8 @@ nb-clean clean < original.ipynb > cleaned.ipynb
 ```
 
 To also remove empty cells, add the `-e`/`--remove-empty-cells` flag. To
-preserve cell metadata, add the `-m`/`--preserve-cell-metadata` flag.
+preserve cell metadata, add the `-m`/`--preserve-cell-metadata` flag. To
+preserve cell outputs, add the `-o`/`--preserve-cell-outputs` flag.
 
 ### Checking
 
@@ -97,7 +104,8 @@ nb-clean check < notebook.ipynb
 ```
 
 To also check for empty cells, add the `-e`/`--remove-empty-cells` flag. To
-ignore cell metadata, add the `-m`/`--preserve-cell-metadata` flag.
+ignore cell metadata, add the `-m`/`--preserve-cell-metadata` flag. To ignore
+cell outputs, add the `-o/--preserve-cell-outputs` flag.
 
 `nb-clean` will exit with status code 0 if the notebook is clean, and status
 code 1 if it is not. `nb-clean` will also print details of cell execution

--- a/src/nb_clean/cli.py
+++ b/src/nb_clean/cli.py
@@ -45,6 +45,7 @@ def add_filter(args: argparse.Namespace) -> None:
         nb_clean.add_git_filter(
             remove_empty_cells=args.remove_empty_cells,
             preserve_cell_metadata=args.preserve_cell_metadata,
+            preserve_cell_outputs=args.preserve_cell_outputs,
         )
     except nb_clean.GitProcessError as exc:
         exit_with_error(exc.message, exc.return_code)
@@ -72,7 +73,8 @@ def check(args: argparse.Namespace) -> None:
     args : argparse.Namespace
         Arguments parsed from the command line. If args.remove_empty_cells
         is True, check for the presence of empty cells. If
-        args.preserve_cell_metadata is True, don't check for cell metadata.
+        args.preserve_cell_metadata is True, don't check for cell metadata. If
+        args.preserve_cell_outputs is True, don't check for cell outputs.
 
     Returns
     -------
@@ -97,6 +99,7 @@ def check(args: argparse.Namespace) -> None:
             notebook,
             remove_empty_cells=args.remove_empty_cells,
             preserve_cell_metadata=args.preserve_cell_metadata,
+            preserve_cell_outputs=args.preserve_cell_outputs,
             filename=name,
         )
         states.append(is_clean)
@@ -113,7 +116,8 @@ def clean(args: argparse.Namespace) -> None:
     args : argparse.Namespace
         Arguments parsed from the command line. If args.remove_empty_cells
         is True, check for empty cells. If args.preserve_cell_metadata is
-        True, don't check for cell metadata.
+        True, don't clean cell metadata. If args.preserve_cell_outputs is True,
+        don't clean cell outputs.
 
     Returns
     -------
@@ -132,6 +136,7 @@ def clean(args: argparse.Namespace) -> None:
             notebook,
             remove_empty_cells=args.remove_empty_cells,
             preserve_cell_metadata=args.preserve_cell_metadata,
+            preserve_cell_outputs=args.preserve_cell_outputs,
         )
         nbformat.write(notebook, output)
 
@@ -171,6 +176,12 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         action="store_true",
         help="preserve cell metadata",
     )
+    add_filter_parser.add_argument(
+        "-o",
+        "--preserve-cell-outputs",
+        action="store_true",
+        help="preserve cell outputs",
+    )
     add_filter_parser.set_defaults(func=add_filter)
 
     remove_filter_parser = subparsers.add_parser(
@@ -205,6 +216,12 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         action="store_true",
         help="preserve cell metadata",
     )
+    check_parser.add_argument(
+        "-o",
+        "--preserve-cell-outputs",
+        action="store_true",
+        help="preserve cell outputs",
+    )
     check_parser.set_defaults(func=check)
 
     clean_parser = subparsers.add_parser(
@@ -229,6 +246,12 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         "--preserve-cell-metadata",
         action="store_true",
         help="preserve cell metadata",
+    )
+    clean_parser.add_argument(
+        "-o",
+        "--preserve-cell-outputs",
+        action="store_true",
+        help="preserve cell outputs",
     )
     clean_parser.set_defaults(func=clean)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,3 +55,9 @@ def clean_notebook_with_empty_cells() -> nbformat.NotebookNode:
 def clean_notebook_with_metadata() -> nbformat.NotebookNode:
     """A clean notebook with cell metadata."""
     return read_notebook("clean_with_metadata.ipynb")
+
+
+@pytest.fixture()
+def clean_notebook_with_outputs() -> nbformat.NotebookNode:
+    """A clean notebook with cell outputs."""
+    return read_notebook("clean_with_outputs.ipynb")

--- a/tests/notebooks/clean_with_outputs.ipynb
+++ b/tests/notebooks/clean_with_outputs.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello, world\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Hello, world\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:Python3] *",
+   "language": "python",
+   "name": "conda-env-Python3-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_check_notebook.py
+++ b/tests/test_check_notebook.py
@@ -50,3 +50,18 @@ def test_check_notebook_preserve_metadata(
         )
         is preserve_cell_metadata
     )
+
+
+@pytest.mark.parametrize("preserve_cell_outputs", [True, False])
+def test_check_notebook_preserve_outputs(
+    clean_notebook_with_outputs: nbformat.NotebookNode,
+    preserve_cell_outputs: bool,
+) -> None:
+    """Test nb_clean.check_notebook when preserving cell outputs."""
+    assert (
+        nb_clean.check_notebook(
+            clean_notebook_with_outputs,
+            preserve_cell_outputs=preserve_cell_outputs,
+        )
+        is preserve_cell_outputs
+    )

--- a/tests/test_clean_notebook.py
+++ b/tests/test_clean_notebook.py
@@ -45,3 +45,14 @@ def test_clean_notebook_preserve_metadata(
         nb_clean.clean_notebook(dirty_notebook, preserve_cell_metadata=True)
         == clean_notebook_with_metadata
     )
+
+
+def test_clean_notebook_preserve_outputs(
+    dirty_notebook: nbformat.NotebookNode,
+    clean_notebook_with_outputs: nbformat.NotebookNode,
+) -> None:
+    """Test nb_clean.clean_notebook when preserving cell outputs."""
+    assert (
+        nb_clean.clean_notebook(dirty_notebook, preserve_cell_outputs=True)
+        == clean_notebook_with_outputs
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,11 +26,15 @@ def test_add_filter(mocker: MockerFixture) -> None:
     mock_add_git_filter = mocker.patch("nb_clean.add_git_filter")
     nb_clean.cli.add_filter(
         argparse.Namespace(
-            remove_empty_cells=True, preserve_cell_metadata=False
+            remove_empty_cells=True,
+            preserve_cell_metadata=False,
+            preserve_cell_outputs=False,
         )
     )
     mock_add_git_filter.assert_called_once_with(
-        remove_empty_cells=True, preserve_cell_metadata=False
+        remove_empty_cells=True,
+        preserve_cell_metadata=False,
+        preserve_cell_outputs=False,
     )
 
 
@@ -45,7 +49,9 @@ def test_add_filter_failure(mocker: MockerFixture) -> None:
     mock_exit_with_error = mocker.patch("nb_clean.cli.exit_with_error")
     nb_clean.cli.add_filter(
         argparse.Namespace(
-            remove_empty_cells=True, preserve_cell_metadata=False
+            remove_empty_cells=True,
+            preserve_cell_metadata=False,
+            preserve_cell_outputs=False,
         )
     )
     mock_exit_with_error.assert_called_once_with("error message", 42)
@@ -95,6 +101,7 @@ def test_check_file(
             inputs=[pathlib.Path("notebook.ipynb")],
             remove_empty_cells=False,
             preserve_cell_metadata=False,
+            preserve_cell_outputs=False,
         )
     )
     mock_read.assert_called_once_with(
@@ -104,6 +111,7 @@ def test_check_file(
         notebook,
         remove_empty_cells=False,
         preserve_cell_metadata=False,
+        preserve_cell_outputs=False,
         filename="notebook.ipynb",
     )
     if clean:
@@ -142,6 +150,7 @@ def test_check_stdin(
             inputs=[],
             remove_empty_cells=False,
             preserve_cell_metadata=False,
+            preserve_cell_outputs=False,
         )
     )
     mock_read.assert_called_once_with(
@@ -151,6 +160,7 @@ def test_check_stdin(
         notebook,
         remove_empty_cells=False,
         preserve_cell_metadata=False,
+        preserve_cell_outputs=False,
         filename="stdin",
     )
     if clean:
@@ -178,6 +188,7 @@ def test_clean_file(
             inputs=[pathlib.Path("notebook.ipynb")],
             remove_empty_cells=False,
             preserve_cell_metadata=False,
+            preserve_cell_outputs=False,
         )
     )
 
@@ -188,6 +199,7 @@ def test_clean_file(
         dirty_notebook,
         remove_empty_cells=False,
         preserve_cell_metadata=False,
+        preserve_cell_outputs=False,
     )
     mock_write.assert_called_once_with(
         clean_notebook, pathlib.Path("notebook.ipynb")
@@ -217,6 +229,7 @@ def test_clean_stdin(
             inputs=[],
             remove_empty_cells=False,
             preserve_cell_metadata=False,
+            preserve_cell_outputs=False,
         )
     )
 
@@ -227,6 +240,7 @@ def test_clean_stdin(
         dirty_notebook,
         remove_empty_cells=False,
         preserve_cell_metadata=False,
+        preserve_cell_outputs=False,
     )
     assert capsys.readouterr().out.strip() == nbformat.writes(clean_notebook)
 
@@ -238,25 +252,42 @@ def test_clean_stdin(
         "inputs",
         "remove_empty_cells",
         "preserve_cell_metadata",
+        "preserve_cell_outputs",
     ),
     [
-        ("add-filter -e", "add_filter", [], True, False),
         (
-            "check -m a.ipynb b.ipynb",
+            "add-filter -e",
+            "add_filter",
+            [],
+            True,
+            False,
+            False,
+        ),
+        (
+            "check -m -o a.ipynb b.ipynb",
             "check",
             "a.ipynb b.ipynb".split(),
             False,
             True,
+            True,
         ),
-        ("clean -e a.ipynb", "clean", ["a.ipynb"], True, False),
+        (
+            "clean -e -o a.ipynb",
+            "clean",
+            ["a.ipynb"],
+            True,
+            False,
+            True,
+        ),
     ],
 )
-def test_parse_args(
+def test_parse_args(  # pylint: disable=too-many-arguments
     argv: str,
     function: str,
     inputs: Iterable[str],
     remove_empty_cells: bool,
     preserve_cell_metadata: bool,
+    preserve_cell_outputs: bool,
 ) -> None:
     """Test nb_clean.cli.parse_args."""
     args = nb_clean.cli.parse_args(argv.split())
@@ -265,3 +296,4 @@ def test_parse_args(
         assert args.inputs == [pathlib.Path(path) for path in inputs]
     assert args.remove_empty_cells is remove_empty_cells
     assert args.preserve_cell_metadata is preserve_cell_metadata
+    assert args.preserve_cell_outputs is preserve_cell_outputs

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -47,23 +47,31 @@ def test_git_attributes_path(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.parametrize(
-    ("remove_empty_cells", "preserve_cell_metadata", "filter_command"),
+    (
+        "remove_empty_cells",
+        "preserve_cell_metadata",
+        "preserve_cell_outputs",
+        "filter_command",
+    ),
     [
-        (False, False, "nb-clean clean"),
-        (True, False, "nb-clean clean --remove-empty-cells"),
-        (False, True, "nb-clean clean --preserve-cell-metadata"),
+        (False, False, False, "nb-clean clean"),
+        (True, False, False, "nb-clean clean --remove-empty-cells"),
+        (False, True, False, "nb-clean clean --preserve-cell-metadata"),
+        (False, False, True, "nb-clean clean --preserve-cell-outputs"),
         (
             True,
             True,
-            "nb-clean clean --remove-empty-cells --preserve-cell-metadata",
+            True,
+            "nb-clean clean --remove-empty-cells --preserve-cell-metadata --preserve-cell-outputs",
         ),
     ],
 )
-def test_add_git_filter(
+def test_add_git_filter(  # pylint: disable=too-many-arguments
     mocker: MockerFixture,
     tmp_path: pathlib.Path,
     remove_empty_cells: bool,
     preserve_cell_metadata: bool,
+    preserve_cell_outputs: bool,
     filter_command: str,
 ) -> None:
     """Test nb_clean.add_git_filter."""
@@ -74,6 +82,7 @@ def test_add_git_filter(
     nb_clean.add_git_filter(
         remove_empty_cells=remove_empty_cells,
         preserve_cell_metadata=preserve_cell_metadata,
+        preserve_cell_outputs=preserve_cell_outputs,
     )
     mock_git.assert_called_once_with(
         "config", "filter.nb-clean.clean", filter_command


### PR DESCRIPTION
Cell outputs can be preserved by passing the `-o`/`--preserve-cell-outputs` flag to the `check`, `clean`, and `add-filter` subcommands.

Thanks to @yasirroni for the initial implementation!

Closes #134.