### PR TITLE
support_dir_for_clean

### DIFF
--- a/src/nb_clean/cli.py
+++ b/src/nb_clean/cli.py
@@ -113,10 +113,13 @@ def clean(args: argparse.Namespace) -> None:
         outputs = [sys.stdout]
 
     for input_, output in zip(inputs, outputs):
-        if input_.is_dir():
-            for input__ in input_.glob('*.ipynb'):
-                _clean(args, input__, input__)
-        else:
+        try:  # pathlib.Path
+            if input_.is_dir():
+                for input__ in input_.glob('*.ipynb'):
+                    _clean(args, input__, input__)
+            else:
+                _clean(args, input_, output)
+        except AttributeError:  # escape _io.TextIOWrapper
             _clean(args, input_, output)
 
 


### PR DESCRIPTION
Support something like:

```python
nb-clean clean notebooks --preserve-cell-outputs
```

Only implemented on `clean`.
___
Test is not written yet, if you want to merge this, I might be able to help to write the test.
___
Anyway, it seems that you use formatter. Can you share the git pre-commit hook?