### PR TITLE
Add `--remove-all-notebook-metadata` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ The check can be run with the following flags:
 - To ignore cell outputs use `--preserve-cell-outputs` or the short form `-o`.
 - To ignore cell execution counts use `--preserve-execution-counts` or the short
   form `-c`.
-- To ignore notebook metadata (such as language version) use
+- To ignore language version notebook metadata use
   `--preserve-notebook-metadata` or the short form `-n`.
+- To check the notebook does not contain any notebook metadata use
+  `--remove-all-notebook-metadata` or the short form `-M`.
 
 For example, to check if a notebook is clean whilst ignoring notebook metadata:
 
@@ -126,6 +128,8 @@ The cleaning can be run with the following flags:
   short form `-c`.
 - To preserve notebook metadata (such as language version) use
   `--preserve-notebook-metadata` or the short form `-n`.
+- To remove all notebook metadata use `--remove-all-notebook-metadata` or the
+  short form `-M`.
 
 For example, to clean a notebook whilst preserving notebook metadata:
 
@@ -186,10 +190,17 @@ To preserve cell execution counts, use:
 nb-clean add-filter --preserve-execution-counts
 ```
 
-To preserve notebook metadata, such as language version, use:
+To preserve notebook `language_info.version` metadata, use:
 
 ```bash
 nb-clean add-filter --preserve-notebook-metadata
+```
+
+By default, `nb-clean` will not delete all notebook metadata. To completely
+remove all notebook metadata:
+
+```bash
+nb-clean add-filter --remove-all-notebook-metadata
 ```
 
 `nb-clean` will configure a filter in the Git repository in which it is run, and

--- a/src/nb_clean/cli.py
+++ b/src/nb_clean/cli.py
@@ -69,6 +69,7 @@ def add_filter(args: argparse.Namespace) -> None:
     try:
         nb_clean.add_git_filter(
             remove_empty_cells=args.remove_empty_cells,
+            remove_all_notebook_metadata=args.remove_all_notebook_metadata,
             preserve_cell_metadata=args.preserve_cell_metadata,
             preserve_cell_outputs=args.preserve_cell_outputs,
             preserve_execution_counts=args.preserve_execution_counts,
@@ -114,6 +115,7 @@ def check(args: argparse.Namespace) -> None:
         is_clean = nb_clean.check_notebook(
             notebook,
             remove_empty_cells=args.remove_empty_cells,
+            remove_all_notebook_metadata=args.remove_all_notebook_metadata,
             preserve_cell_metadata=args.preserve_cell_metadata,
             preserve_cell_outputs=args.preserve_cell_outputs,
             preserve_execution_counts=args.preserve_execution_counts,
@@ -152,6 +154,7 @@ def clean(args: argparse.Namespace) -> None:
         notebook = nb_clean.clean_notebook(
             notebook,
             remove_empty_cells=args.remove_empty_cells,
+            remove_all_notebook_metadata=args.remove_all_notebook_metadata,
             preserve_cell_metadata=args.preserve_cell_metadata,
             preserve_cell_outputs=args.preserve_cell_outputs,
             preserve_execution_counts=args.preserve_execution_counts,
@@ -180,6 +183,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
     )
     add_filter_parser.add_argument(
         "-e", "--remove-empty-cells", action="store_true", help="remove empty cells"
+    )
+    add_filter_parser.add_argument(
+        "-M",
+        "--remove-all-notebook-metadata",
+        action="store_true",
+        help="remove all notebook metadata",
     )
     add_filter_parser.add_argument(
         "-m",
@@ -227,6 +236,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         "-e", "--remove-empty-cells", action="store_true", help="check for empty cells"
     )
     check_parser.add_argument(
+        "-M",
+        "--remove-all-notebook-metadata",
+        action="store_true",
+        help="check for any notebook metadata",
+    )
+    check_parser.add_argument(
         "-m",
         "--preserve-cell-metadata",
         default=None,
@@ -261,6 +276,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
     )
     clean_parser.add_argument(
         "-e", "--remove-empty-cells", action="store_true", help="remove empty cells"
+    )
+    clean_parser.add_argument(
+        "-M",
+        "--remove-all-notebook-metadata",
+        action="store_true",
+        help="remove all notebook metadata",
     )
     clean_parser.add_argument(
         "-m",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,3 +99,9 @@ def clean_notebook_with_outputs() -> nbformat.NotebookNode:
 def clean_notebook_with_outputs_with_counts() -> nbformat.NotebookNode:
     """Return a notebook with cell outputs and output execution counts."""
     return read_notebook("clean_with_outputs_with_counts.ipynb")
+
+
+@pytest.fixture()
+def clean_notebook_without_notebook_metadata() -> nbformat.NotebookNode:
+    """Return a clean notebook without notebook metadata."""
+    return read_notebook("clean_without_notebook_metadata.ipynb")

--- a/tests/notebooks/clean_without_notebook_metadata.ipynb
+++ b/tests/notebooks/clean_without_notebook_metadata.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = \"Hello, world\"\n",
+    "text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/notebooks/dirty_empty_octave.ipynb
+++ b/tests/notebooks/dirty_empty_octave.ipynb
@@ -1,0 +1,21 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10cfba24-bab5-47a0-9ab8-5d1fc01f1f58",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Octave",
+   "language": "octave",
+   "name": "octave"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_check_notebook.py
+++ b/tests/test_check_notebook.py
@@ -175,3 +175,51 @@ def test_check_notebook_preserve_execution_counts(
         notebook, preserve_execution_counts=preserve_execution_counts
     )
     assert output is is_clean
+
+
+@pytest.mark.parametrize(
+    ("notebook_name", "remove_all_notebook_metadata", "is_clean"),
+    [
+        ("clean_notebook_with_notebook_metadata", True, False),
+        ("clean_notebook_with_notebook_metadata", False, False),
+        ("clean_notebook_without_notebook_metadata", True, True),
+        ("clean_notebook_without_notebook_metadata", False, True),
+        ("clean_notebook", True, False),
+        ("clean_notebook", False, True),
+    ],
+)
+def test_check_notebook_remove_all_notebook_metadata(
+    notebook_name: str,
+    *,
+    remove_all_notebook_metadata: bool,
+    is_clean: bool,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Test nb_clean.clean_notebook when removing all notebook metadata.
+
+    The test with `("clean_notebook_with_notebook_metadata", False, True)` is False due
+    to `clean_notebook_with_notebook_metadata` containing `language_info.version`
+    detected when `preserve_notebook_metadata=False`.
+    """
+    notebook = request.getfixturevalue(notebook_name)
+    assert (
+        nb_clean.check_notebook(
+            notebook, remove_all_notebook_metadata=remove_all_notebook_metadata
+        )
+        == is_clean
+    )
+
+
+def test_check_notebook_exclusive_arguments(
+    dirty_notebook: nbformat.NotebookNode,
+) -> None:
+    """Test nb_clean.check_notebook with invalid arguments."""
+    with pytest.raises(
+        ValueError,
+        match="`preserve_notebook_metadata` and `remove_all_notebook_metadata` cannot both be `True`",
+    ):
+        nb_clean.check_notebook(
+            dirty_notebook,
+            remove_all_notebook_metadata=True,
+            preserve_notebook_metadata=True,
+        )

--- a/tests/test_clean_notebook.py
+++ b/tests/test_clean_notebook.py
@@ -119,3 +119,29 @@ def test_clean_notebook_preserve_execution_counts(
         nb_clean.clean_notebook(dirty_notebook, preserve_execution_counts=True)
         == clean_notebook_with_counts
     )
+
+
+def test_clean_notebook_remove_all_notebook_metadata(
+    dirty_notebook: nbformat.NotebookNode,
+    clean_notebook_without_notebook_metadata: nbformat.NotebookNode,
+) -> None:
+    """Test nb_clean.clean_notebook when removing all notebook metadata."""
+    assert (
+        nb_clean.clean_notebook(dirty_notebook, remove_all_notebook_metadata=True)
+        == clean_notebook_without_notebook_metadata
+    )
+
+
+def test_clean_notebook_exclusive_arguments(
+    dirty_notebook: nbformat.NotebookNode,
+) -> None:
+    """Test nb_clean.clean_notebook with invalid arguments."""
+    with pytest.raises(
+        ValueError,
+        match="`preserve_notebook_metadata` and `remove_all_notebook_metadata` cannot both be `True`",
+    ):
+        nb_clean.clean_notebook(
+            dirty_notebook,
+            remove_all_notebook_metadata=True,
+            preserve_notebook_metadata=True,
+        )


### PR DESCRIPTION
Add new argument for clean and filter "-M" or "--remove-notebook-metadata" to "remove notebook metadata.

```python
    clean_parser.add_argument(
        "-M",
        "--remove-notebook-metadata",
        action="store_true",
        help="remove notebook metadata",
    )
```