### PR TITLE
Add preserve execution counts option

### DIFF
--- a/src/nb_clean/cli.py
+++ b/src/nb_clean/cli.py
@@ -59,7 +59,8 @@ def add_filter(args: argparse.Namespace) -> None:
         Arguments parsed from the command line. If args.remove_empty_cells
         is True, configure the filter to remove empty cells. If
         args.preserve_cell_metadata is True, configure the filter to
-        preserve cell metadata.
+        preserve cell metadata. If args.preserve_execution_counts is True,
+        configure the filter to preserve cell execution counts.
 
     """
     try:
@@ -67,6 +68,7 @@ def add_filter(args: argparse.Namespace) -> None:
             remove_empty_cells=args.remove_empty_cells,
             preserve_cell_metadata=args.preserve_cell_metadata,
             preserve_cell_outputs=args.preserve_cell_outputs,
+            preserve_execution_counts=args.preserve_execution_counts,
         )
     except nb_clean.GitProcessError as exc:
         exit_with_error(exc.message, exc.return_code)
@@ -89,7 +91,9 @@ def check(args: argparse.Namespace) -> None:
         Arguments parsed from the command line. If args.remove_empty_cells
         is True, check for the presence of empty cells. If
         args.preserve_cell_metadata is True, don't check for cell metadata. If
-        args.preserve_cell_outputs is True, don't check for cell outputs.
+        args.preserve_cell_outputs is True, don't check for cell outputs. If
+        args.preserve_execution_counts is True, don't check for cell execution
+        counts.
 
     """
     if args.inputs:
@@ -107,6 +111,7 @@ def check(args: argparse.Namespace) -> None:
             remove_empty_cells=args.remove_empty_cells,
             preserve_cell_metadata=args.preserve_cell_metadata,
             preserve_cell_outputs=args.preserve_cell_outputs,
+            preserve_execution_counts=args.preserve_execution_counts,
             filename=name,
         )
         states.append(is_clean)
@@ -124,7 +129,8 @@ def clean(args: argparse.Namespace) -> None:
         Arguments parsed from the command line. If args.remove_empty_cells
         is True, check for empty cells. If args.preserve_cell_metadata is
         True, don't clean cell metadata. If args.preserve_cell_outputs is True,
-        don't clean cell outputs.
+        don't clean cell outputs. If args.preserve_execution_counts is True,
+        don't clean cell execution counts.
 
     """
     if args.inputs:
@@ -141,6 +147,7 @@ def clean(args: argparse.Namespace) -> None:
             remove_empty_cells=args.remove_empty_cells,
             preserve_cell_metadata=args.preserve_cell_metadata,
             preserve_cell_outputs=args.preserve_cell_outputs,
+            preserve_execution_counts=args.preserve_execution_counts,
         )
         nbformat.write(notebook, output)  # type: ignore[no-untyped-call]
 
@@ -180,6 +187,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         action="store_true",
         help="preserve cell outputs",
     )
+    add_filter_parser.add_argument(
+        "-c",
+        "--preserve-execution-counts",
+        action="store_true",
+        help="preserve cell execution counts",
+    )
     add_filter_parser.set_defaults(func=add_filter)
 
     remove_filter_parser = subparsers.add_parser(
@@ -213,6 +226,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         action="store_true",
         help="preserve cell outputs",
     )
+    check_parser.add_argument(
+        "-c",
+        "--preserve-execution-counts",
+        action="store_true",
+        help="preserve cell execution counts",
+    )
     check_parser.set_defaults(func=check)
 
     clean_parser = subparsers.add_parser(
@@ -236,6 +255,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         "--preserve-cell-outputs",
         action="store_true",
         help="preserve cell outputs",
+    )
+    clean_parser.add_argument(
+        "-c",
+        "--preserve-execution-counts",
+        action="store_true",
+        help="preserve cell execution counts",
     )
     clean_parser.set_defaults(func=clean)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,12 @@ def clean_notebook_with_empty_cells() -> nbformat.NotebookNode:
 
 
 @pytest.fixture()
+def clean_notebook_with_counts() -> nbformat.NotebookNode:
+    """Return a clean notebook with only input cell execution counts."""
+    return read_notebook("clean_with_counts.ipynb")
+
+
+@pytest.fixture()
 def clean_notebook_with_metadata() -> nbformat.NotebookNode:
     """Return a clean notebook with cell metadata."""
     return read_notebook("clean_with_metadata.ipynb")

--- a/tests/notebooks/clean_with_counts.ipynb
+++ b/tests/notebooks/clean_with_counts.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = \"Hello, world\"\n",
+    "text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:Python3] *",
+   "language": "python",
+   "name": "conda-env-Python3-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_check_notebook.py
+++ b/tests/test_check_notebook.py
@@ -141,3 +141,28 @@ def test_check_notebook_preserve_outputs(
         notebook, preserve_cell_outputs=preserve_cell_outputs
     )
     assert output is is_clean
+
+
+@pytest.mark.parametrize(
+    ("notebook", "preserve_execution_counts", "is_clean"),
+    [
+        (
+            pytest.lazy_fixture("clean_notebook_with_counts"),  # type: ignore[operator]
+            True,
+            True,
+        ),
+        (
+            pytest.lazy_fixture("clean_notebook_with_counts"),  # type: ignore[operator]
+            False,
+            False,
+        ),
+    ],
+)
+def test_check_notebook_preserve_execution_counts(
+    notebook: nbformat.NotebookNode, *, preserve_execution_counts: bool, is_clean: bool
+) -> None:
+    """Test nb_clean.check_notebook when preserving cell execution counts."""
+    output = nb_clean.check_notebook(
+        notebook, preserve_execution_counts=preserve_execution_counts
+    )
+    assert output is is_clean

--- a/tests/test_clean_notebook.py
+++ b/tests/test_clean_notebook.py
@@ -94,3 +94,14 @@ def test_clean_notebook_preserve_outputs(
         nb_clean.clean_notebook(dirty_notebook, preserve_cell_outputs=True)
         == clean_notebook_with_outputs
     )
+
+
+def test_clean_notebook_preserve_execution_counts(
+    dirty_notebook: nbformat.NotebookNode,
+    clean_notebook_with_counts: nbformat.NotebookNode,
+) -> None:
+    """Test nb_clean.clean_notebook when preserving cell execution counts."""
+    assert (
+        nb_clean.clean_notebook(dirty_notebook, preserve_execution_counts=True)
+        == clean_notebook_with_counts
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,12 +47,14 @@ def test_add_filter(mocker: MockerFixture) -> None:
             remove_empty_cells=True,
             preserve_cell_metadata=None,
             preserve_cell_outputs=False,
+            preserve_execution_counts=False,
         )
     )
     mock_add_git_filter.assert_called_once_with(
         remove_empty_cells=True,
         preserve_cell_metadata=None,
         preserve_cell_outputs=False,
+        preserve_execution_counts=False,
     )
 
 
@@ -68,6 +70,7 @@ def test_add_filter_failure(mocker: MockerFixture) -> None:
             remove_empty_cells=True,
             preserve_cell_metadata=None,
             preserve_cell_outputs=False,
+            preserve_execution_counts=False,
         )
     )
     mock_exit_with_error.assert_called_once_with("error message", 42)
@@ -111,6 +114,7 @@ def test_check_file(
             remove_empty_cells=False,
             preserve_cell_metadata=None,
             preserve_cell_outputs=False,
+            preserve_execution_counts=False,
         )
     )
     mock_read.assert_called_once_with(
@@ -121,6 +125,7 @@ def test_check_file(
         remove_empty_cells=False,
         preserve_cell_metadata=None,
         preserve_cell_outputs=False,
+        preserve_execution_counts=False,
         filename="notebook.ipynb",
     )
     if clean:
@@ -152,6 +157,7 @@ def test_check_stdin(
             remove_empty_cells=False,
             preserve_cell_metadata=None,
             preserve_cell_outputs=False,
+            preserve_execution_counts=False,
         )
     )
     mock_read.assert_called_once_with(sys.stdin, as_version=nbformat.NO_CONVERT)
@@ -160,6 +166,7 @@ def test_check_stdin(
         remove_empty_cells=False,
         preserve_cell_metadata=None,
         preserve_cell_outputs=False,
+        preserve_execution_counts=False,
         filename="stdin",
     )
     if clean:
@@ -186,6 +193,7 @@ def test_clean_file(
             remove_empty_cells=False,
             preserve_cell_metadata=None,
             preserve_cell_outputs=False,
+            preserve_execution_counts=False,
         )
     )
 
@@ -197,6 +205,7 @@ def test_clean_file(
         remove_empty_cells=False,
         preserve_cell_metadata=None,
         preserve_cell_outputs=False,
+        preserve_execution_counts=False,
     )
     mock_write.assert_called_once_with(clean_notebook, pathlib.Path("notebook.ipynb"))
 
@@ -223,6 +232,7 @@ def test_clean_stdin(
             remove_empty_cells=False,
             preserve_cell_metadata=None,
             preserve_cell_outputs=False,
+            preserve_execution_counts=False,
         )
     )
 
@@ -232,6 +242,7 @@ def test_clean_stdin(
         remove_empty_cells=False,
         preserve_cell_metadata=None,
         preserve_cell_outputs=False,
+        preserve_execution_counts=False,
     )
     assert capsys.readouterr().out.strip() == nbformat.writes(clean_notebook)  # type: ignore[no-untyped-call]
 
@@ -244,9 +255,10 @@ def test_clean_stdin(
         "remove_empty_cells",
         "preserve_cell_metadata",
         "preserve_cell_outputs",
+        "preserve_execution_counts",
     ),
     [
-        ("add-filter -e", "add_filter", [], True, None, False),
+        ("add-filter -e", "add_filter", [], True, None, False, False),
         (
             "check -m -o a.ipynb b.ipynb",
             "check",
@@ -254,6 +266,7 @@ def test_clean_stdin(
             False,
             [],
             True,
+            False,
         ),
         (
             "check -m tags -o a.ipynb b.ipynb",
@@ -262,6 +275,7 @@ def test_clean_stdin(
             False,
             ["tags"],
             True,
+            False,
         ),
         (
             "check -m tags special -o a.ipynb b.ipynb",
@@ -270,8 +284,10 @@ def test_clean_stdin(
             False,
             ["tags", "special"],
             True,
+            False,
         ),
-        ("clean -e -o a.ipynb", "clean", ["a.ipynb"], True, None, True),
+        ("clean -e -o a.ipynb", "clean", ["a.ipynb"], True, None, True, False),
+        ("clean -e -c -o a.ipynb", "clean", ["a.ipynb"], True, None, True, True),
     ],
 )
 def test_parse_args(
@@ -282,6 +298,7 @@ def test_parse_args(
     remove_empty_cells: bool,
     preserve_cell_metadata: Collection[str] | None,
     preserve_cell_outputs: bool,
+    preserve_execution_counts: bool,
 ) -> None:
     """Test nb_clean.cli.parse_args."""
     args = nb_clean.cli.parse_args(argv.split())
@@ -291,3 +308,4 @@ def test_parse_args(
     assert args.remove_empty_cells is remove_empty_cells
     assert args.preserve_cell_metadata == preserve_cell_metadata
     assert args.preserve_cell_outputs is preserve_cell_outputs
+    assert args.preserve_execution_counts is preserve_execution_counts

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -53,26 +53,30 @@ def test_git_attributes_path(mocker: MockerFixture) -> None:
         "remove_empty_cells",
         "preserve_cell_metadata",
         "preserve_cell_outputs",
+        "preserve_execution_counts",
         "filter_command",
     ),
     [
-        (False, None, False, "nb-clean clean"),
-        (True, None, False, "nb-clean clean --remove-empty-cells"),
-        (False, [], False, "nb-clean clean --preserve-cell-metadata"),
-        (False, ["tags"], False, "nb-clean clean --preserve-cell-metadata tags"),
+        (False, None, False, False, "nb-clean clean"),
+        (True, None, False, False, "nb-clean clean --remove-empty-cells"),
+        (False, [], False, False, "nb-clean clean --preserve-cell-metadata"),
+        (False, ["tags"], False, False, "nb-clean clean --preserve-cell-metadata tags"),
         (
             False,
             ["tags", "special"],
             False,
+            False,
             "nb-clean clean --preserve-cell-metadata tags special",
         ),
-        (False, None, True, "nb-clean clean --preserve-cell-outputs"),
+        (False, None, True, False, "nb-clean clean --preserve-cell-outputs"),
         (
             True,
             [],
             True,
+            False,
             "nb-clean clean --remove-empty-cells --preserve-cell-metadata --preserve-cell-outputs",
         ),
+        (False, None, False, True, "nb-clean clean --preserve-execution-counts"),
     ],
 )
 def test_add_git_filter(
@@ -82,6 +86,7 @@ def test_add_git_filter(
     remove_empty_cells: bool,
     preserve_cell_metadata: Collection[str] | None,
     preserve_cell_outputs: bool,
+    preserve_execution_counts: bool,
     filter_command: str,
 ) -> None:
     """Test nb_clean.add_git_filter."""
@@ -93,6 +98,7 @@ def test_add_git_filter(
         remove_empty_cells=remove_empty_cells,
         preserve_cell_metadata=preserve_cell_metadata,
         preserve_cell_outputs=preserve_cell_outputs,
+        preserve_execution_counts=preserve_execution_counts,
     )
     mock_git.assert_called_once_with("config", "filter.nb-clean.clean", filter_command)
     mock_git_attributes_path.assert_called_once()


### PR DESCRIPTION
Closes #221 .

The implementation is fairly straightforward. I added the `preserve_execution_counts` option for `add_filter`, `check` and `clean` subcommands.

Just one thing to check:

* I chose `-c` as the short option name for `preserve_execution_counts`, let me know if you want to change it to something else.